### PR TITLE
Enhance middleware to support public route handling

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,12 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
-export default clerkMiddleware();
+const isPublicRoute = createRouteMatcher(["/api/webhooks(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isPublicRoute(req)) return NextResponse.next();
+  await auth.protect();
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
- Integrated `createRouteMatcher` to define public routes for webhook handling.
- Updated `clerkMiddleware` to allow public access to specified routes while protecting others.
- Ensured existing authentication functionality remains intact while improving route management.